### PR TITLE
Local time

### DIFF
--- a/example_config/Settings.json
+++ b/example_config/Settings.json
@@ -28,7 +28,8 @@
     "clusterConfigurationFile": "../local/config/ClusterConfig.xml"
   },
   "schedulerSettings": {
-    "timeTransmissionCron": "0 0/1 * * * ?",
+    "timeTransmissionCron": "0 0/2 * * * ?",
+    "localTimeTransmissionCron": "0 1/1 * * * ?",
     "rubricNameTransmissionCron": "15 0/5 * * * ?",
     "stateSavingCron": "30 0/10 * * * ?",
     "stateCleaningCron": "0 0 0 * * ?"

--- a/src/main/java/org/dapnet/core/scheduler/LocalTimeTransmissionJob.java
+++ b/src/main/java/org/dapnet/core/scheduler/LocalTimeTransmissionJob.java
@@ -26,7 +26,7 @@ import org.quartz.JobExecutionException;
 import org.quartz.SchedulerContext;
 import org.quartz.SchedulerException;
 
-public class TimeTransmissionJob implements Job {
+public class LocalTimeTransmissionJob implements Job {
 	private static final Logger logger = LogManager.getLogger();
 
 	@Override
@@ -39,8 +39,8 @@ public class TimeTransmissionJob implements Job {
 
 			// Possibility to implement TimeZones by adding here a
 			// TransmitterGroup
-			LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
-			transmissionManager.handleTime(now);
+			LocalDateTime localtime = LocalDateTime.now();
+			transmissionManager.handleLocalTime(localtime);
 		} catch (SchedulerException e) {
 			logger.error("Failed to execute TimeTransmissionJob", e);
 		}

--- a/src/main/java/org/dapnet/core/scheduler/SchedulerManager.java
+++ b/src/main/java/org/dapnet/core/scheduler/SchedulerManager.java
@@ -42,6 +42,7 @@ public class SchedulerManager {
 		scheduler.start();
 
 		registerTimeTransmissionJob();
+		registerLocalTimeTransmissionJob();
 		registerRubricNameTransmissionJob();
 		registerNewsTransmissionJob();
 		registerStateSavingJob();
@@ -55,6 +56,13 @@ public class SchedulerManager {
 		JobDetail job = newJob(TimeTransmissionJob.class).withIdentity("timeTransmissionJob", "main").build();
 		CronTrigger trigger = newTrigger().withIdentity("timeTransmissionTrigger", "main")
 				.withSchedule(cronSchedule(Settings.getSchedulerSettings().getTimeTransmissionCron())).build();
+		scheduler.scheduleJob(job, trigger);
+	}
+
+	private void registerLocalTimeTransmissionJob() throws SchedulerException {
+		JobDetail job = newJob(LocalTimeTransmissionJob.class).withIdentity("localTimeTransmissionJob", "main").build();
+		CronTrigger trigger = newTrigger().withIdentity("localTimeTransmissionTrigger", "main")
+				.withSchedule(cronSchedule(Settings.getSchedulerSettings().getLocalTimeTransmissionCron())).build();
 		scheduler.scheduleJob(job, trigger);
 	}
 

--- a/src/main/java/org/dapnet/core/scheduler/SchedulerSettings.java
+++ b/src/main/java/org/dapnet/core/scheduler/SchedulerSettings.java
@@ -19,6 +19,7 @@ import java.io.Serializable;
 public class SchedulerSettings implements Serializable {
 	private static final long serialVersionUID = -8720953587062509265L;
 	private String timeTransmissionCron = "0 0/20 * * * ?";
+	private String localTimeTransmissionCron = "0 10/20 * * * ?";
 	private String rubricNameTransmissionCron = "15 0/20 * * * ?";
 	private String newsTransmissionCron = "45 0 * * * ?";
 	private String stateSavingCron = "30 0/10 * * * ?";
@@ -27,6 +28,10 @@ public class SchedulerSettings implements Serializable {
 
 	public String getTimeTransmissionCron() {
 		return timeTransmissionCron;
+	}
+
+	public String getLocalTimeTransmissionCron() {
+		return localTimeTransmissionCron;
 	}
 
 	public String getRubricNameTransmissionCron() {

--- a/src/main/java/org/dapnet/core/scheduler/TimeTransmissionJob.java
+++ b/src/main/java/org/dapnet/core/scheduler/TimeTransmissionJob.java
@@ -41,6 +41,8 @@ public class TimeTransmissionJob implements Job {
 			// TransmitterGroup
 			LocalDateTime now = LocalDateTime.now(ZoneOffset.UTC);
 			transmissionManager.handleTime(now);
+			LocalDateTime localtime = LocalDateTime.now();
+			transmissionManager.handleLocalTime(localtime);
 		} catch (SchedulerException e) {
 			logger.error("Failed to execute TimeTransmissionJob", e);
 		}

--- a/src/main/java/org/dapnet/core/transmission/PagerProtocol.java
+++ b/src/main/java/org/dapnet/core/transmission/PagerProtocol.java
@@ -27,7 +27,11 @@ public interface PagerProtocol {
 
 	PagerMessage createMessageFromTimeSwissphone(LocalDateTime time);
 
+	PagerMessage createMessageFromLocalTimeSwissphone(LocalDateTime time);
+
 	PagerMessage createMessageFromTimeAlphaPoc(LocalDateTime time);
+
+	PagerMessage createMessageFromLocalTimeAlphaPoc(LocalDateTime time);
 
 	PagerMessage createMessageFromRubric(Rubric rubric);
 

--- a/src/main/java/org/dapnet/core/transmission/SkyperProtocol.java
+++ b/src/main/java/org/dapnet/core/transmission/SkyperProtocol.java
@@ -103,26 +103,26 @@ public class SkyperProtocol implements PagerProtocol {
 	public PagerMessage createMessageFromTimeSwissphone(LocalDateTime time) {
 		String s = DATE_FORMATTER_SWISSPHONE.format(time);
 		String s2 = s + s;
-		return new PagerMessage(s2, 165856, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
+		return new PagerMessage(s2, 200, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
 	}
 
 	@Override
 	public PagerMessage createMessageFromLocalTimeSwissphone(LocalDateTime localTime) {
 		String s = DATE_FORMATTER_SWISSPHONE.format(localTime);
 		String s2 = s + s;
-		return new PagerMessage(s2, 165857, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
+		return new PagerMessage(s2, 208, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
 	}
 
 	@Override
 	public PagerMessage createMessageFromTimeAlphaPoc(LocalDateTime time) {
 		String s = DATE_FORMATTER_ALPHAPOC.format(time);
-		return new PagerMessage(s, 165866, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
+		return new PagerMessage(s, 216, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
 	}
 
 	@Override
 	public PagerMessage createMessageFromLocalTimeAlphaPoc(LocalDateTime time) {
 		String s = DATE_FORMATTER_ALPHAPOC.format(time);
-		return new PagerMessage(s, 165867, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
+		return new PagerMessage(s, 224, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
 	}
 
 	@Override

--- a/src/main/java/org/dapnet/core/transmission/SkyperProtocol.java
+++ b/src/main/java/org/dapnet/core/transmission/SkyperProtocol.java
@@ -107,9 +107,22 @@ public class SkyperProtocol implements PagerProtocol {
 	}
 
 	@Override
+	public PagerMessage createMessageFromLocalTimeSwissphone(LocalDateTime localTime) {
+		String s = DATE_FORMATTER_SWISSPHONE.format(localTime);
+		String s2 = s + s;
+		return new PagerMessage(s2, 165857, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
+	}
+
+	@Override
 	public PagerMessage createMessageFromTimeAlphaPoc(LocalDateTime time) {
 		String s = DATE_FORMATTER_ALPHAPOC.format(time);
 		return new PagerMessage(s, 165866, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
+	}
+
+	@Override
+	public PagerMessage createMessageFromLocalTimeAlphaPoc(LocalDateTime time) {
+		String s = DATE_FORMATTER_ALPHAPOC.format(time);
+		return new PagerMessage(s, 165867, PagerMessage.MessagePriority.TIME, PagerMessage.FunctionalBits.ALPHANUM);
 	}
 
 	@Override

--- a/src/main/java/org/dapnet/core/transmission/TransmissionManager.java
+++ b/src/main/java/org/dapnet/core/transmission/TransmissionManager.java
@@ -66,6 +66,29 @@ public class TransmissionManager {
 
 	}
 
+	public void handleLocalTime(LocalDateTime time) {
+		// Swissphone Time in local time
+		try {
+			PagerMessage message = protocol.createMessageFromLocalTimeSwissphone(time);
+			transmitterManager.sendMessage(message);
+
+			logger.info("Local time sent to transmitters in Swissphone format.");
+		} catch (Exception e) {
+			logger.error("Failed to send local time in Swissphone format.", e);
+		}
+
+		// AlphaPoc Time in local time
+		try {
+			PagerMessage message = protocol.createMessageFromLocalTimeAlphaPoc(time);
+			transmitterManager.sendMessage(message);
+
+			logger.info("Local time sent to transmitters in AlphaPoc format.");
+		} catch (Exception e) {
+			logger.error("Failed to send local time in AlphaPoc format.", e);
+		}
+
+	}
+
 	public void handleNews(News news) {
 		try {
 			PagerMessage message = protocol.createMessageFromNews(news);


### PR DESCRIPTION
This implements a second RIC for AlphaPoc and Swissphone pagers that is used to broadcast local time along with UTC.
Also the RICs used for time transmission have changed. The new ones are:
- 200 for Swissphone UTC time
- 208 for Swissphone local time
- 216 for AlphaPoc UTC time
- 224 for AlphaPoc local time
Default schedule is to broadcast UTC on even minutes and local time on odd.