### PR TITLE
Extend Skyper acitvation to 11/26

### DIFF
--- a/example_config/Settings.json
+++ b/example_config/Settings.json
@@ -3,7 +3,7 @@
     "pagingProtocolSettings": {
       "numberOfSyncLoops": 5,
       "sendSpeed": 1,
-      "activationCode": "0 7 50,0 7 34,0 7 53,0 7 51,0 7 51,0 7 52,0 7 52,0 7 52"
+      "activationCode": "0 7 50,0 7 34,0 7 53,0 7 51,0 7 51,0 7 52,0 7 52,0 7 56"
     },
     "raspagerSettings": {
       "maxNumberOfReconnects": -1,

--- a/src/main/java/org/dapnet/core/transmission/TransmissionSettings.java
+++ b/src/main/java/org/dapnet/core/transmission/TransmissionSettings.java
@@ -33,7 +33,7 @@ public final class TransmissionSettings implements Serializable {
 		private static final long serialVersionUID = 2535179621136596934L;
 		private int numberOfSyncLoops = 5;
 		private int sendSpeed = 1;// 0: 512, 1: 1200, 2:2400
-		private String activationCode = "0 7 50,0 7 34,0 7 53,0 7 51,0 7 51,0 7 52,0 7 52,0 7 52";
+		private String activationCode = "0 7 50,0 7 34,0 7 53,0 7 51,0 7 51,0 7 52,0 7 52,0 7 56";
 
 		public int getNumberOfSyncLoops() {
 			return numberOfSyncLoops;


### PR DESCRIPTION
This patch would extend the activation period to November 2026. Beyond that is currently impossible/unknown due to the calendar flipping over to 1996 after 2026. Patch is based on work by Martin DG1KMM. This adresses issue https://github.com/DecentralizedAmateurPagingNetwork/Core/issues/166