### PR TITLE
feat: Add support for optional explicit subric per pager

### DIFF
--- a/src/main/java/org/dapnet/core/model/Pager.java
+++ b/src/main/java/org/dapnet/core/model/Pager.java
@@ -33,6 +33,18 @@ public class Pager implements Serializable {
 	@Size(min = 3, max = 20)
 	private String name;
 
+	@Min(value = 0, message = "subric must be in range 0-3")
+	@Max(value = 3, message = "subric must be in range 0-3")
+	private Integer subric;
+
+	public Integer getSubric() {
+		return subric;
+	}
+
+	public void setSubric(Integer subric) {
+		this.subric = subric;
+	}
+
 	public int getNumber() {
 		return number;
 	}

--- a/src/main/java/org/dapnet/core/transmission/PagerMessage.java
+++ b/src/main/java/org/dapnet/core/transmission/PagerMessage.java
@@ -15,6 +15,7 @@
 package org.dapnet.core.transmission;
 
 import java.time.Instant;
+import java.util.stream.Stream;
 
 public class PagerMessage implements Comparable<PagerMessage> {
 	private final String text;
@@ -38,6 +39,10 @@ public class PagerMessage implements Comparable<PagerMessage> {
 
 		public int getValue() {
 			return value;
+		}
+
+		public static FunctionalBits fromSubric(int subric, FunctionalBits fallback) {
+			return Stream.of(values()).filter(fb -> fb.value == subric).findFirst().orElse(fallback);
 		}
 	}
 

--- a/src/main/java/org/dapnet/core/transmission/SkyperProtocol.java
+++ b/src/main/java/org/dapnet/core/transmission/SkyperProtocol.java
@@ -82,6 +82,9 @@ public class SkyperProtocol implements PagerProtocol {
 				}
 
 				for (Pager pager : callsign.getPagers()) {
+					if (pager.getSubric() != null) {
+						mode = FunctionalBits.fromSubric(pager.getSubric(), mode);
+					}
 					messages.add(new PagerMessage(now, text, pager.getNumber(), priority, mode));
 				}
 			}


### PR DESCRIPTION
With this small feature it is possible to specify an optional explicit SubRIC (A-D) when creating pagers and assigning RICs. If a SubRIC is set, this will override the default SubRIC (ALPHANUM = 3) for an individual call. This feature therefore only works for pagers other than Skyper. (Transmissions of Rubrics/News/Time/StationId are not affected).

Since specifying the SubRIC is optional, all subscribers/pagers currently stored in DAPNET will work as before.