### PR TITLE
fix: Missing 7-Bit encoding when sending News as Call

### DIFF
--- a/src/main/java/org/dapnet/core/transmission/SkyperProtocol.java
+++ b/src/main/java/org/dapnet/core/transmission/SkyperProtocol.java
@@ -167,7 +167,8 @@ public class SkyperProtocol implements PagerProtocol {
 	@Override
 	public PagerMessage createMessageFromNewsAsCall(News news) {
 		try {
-			return new PagerMessage(news.getText(), news.getRubric().getAddress(), PagerMessage.MessagePriority.CALL,
+			String text = encodeString(news.getText());
+			return new PagerMessage(text, news.getRubric().getAddress(), PagerMessage.MessagePriority.CALL,
 					PagerMessage.FunctionalBits.ALPHANUM);
 		} catch (Exception ex) {
 			return null;


### PR DESCRIPTION
When Rubric News are sent as Calls (RIC 10XX), the text is not encoded with the DE_ASCII7 charset.