### PR TITLE
fix: Move NodeName + ChannelName to settings.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,24 @@ included. Just make sure a JAVA 8+ runtime environment is available.
 If you would like to join an existing cluster contact an admin. He will register your
 DAPNET Core instance and inform you about the configuration. If you want to create a new
 cluster feel free to set your own configuration. In each case set the following parameters
-in the `local/config/ClusterConfig.xml`:
+in the `local/config/ClusterConfig.xml` and `local/config/Settings.json` :
 
-* Node name (name of your DAPNET Core instance) at
-  `<pbcast.GMS name="NodeName@ClusterName"/>`
-* Cluster name (name of the DAPNET Cluster) at `<pbcast.GMS name="NodeName@ClusterName"/>`
+* Node name (name of your DAPNET Core instance) and cluster name (name of the DAPNET Cluster) at Settings.json
+  ```
+  ...
+  "clusterSettings": {
+      ...
+      "nodeName": "THIS_IS_YOUR_CALLSIGN_AS_ITS_IN_SETUP_IN_THE_CLUSTER",
+      "channelName": "DAPNET"
+  },
+  ...
+  
 * Node authentication key (needed for authentication if you want to rejoin your cluster
-  later) of form XXXX-XXXX-XXXX-XXXX-XXXX (X is alphanumeric) at
+  later) of form XXXX-XXXX-XXXX-XXXX-XXXX (X is alphanumeric) at ClusterConfig.xml \
   `<AUTH auth_value="key"/>`
 * Initial hosts (if you want to join an existing cluster at least one node have to be
-  known... ) at `<TCPPING initial_hosts="HostA[7800],HostB[7800]\>`
+  known... ) at ClusterConfig.xml \
+  `<TCPPING initial_hosts="HostA[7800],HostB[7800]\>`
 
 #### Log Settings ####
 The DAPNET Core uses Log4j2 for logging, which can be configured in the

--- a/example_config/ClusterConfig.xml
+++ b/example_config/ClusterConfig.xml
@@ -44,8 +44,6 @@
     <FRAG2/>
     <pbcast.STATE_TRANSFER/>
     <pbcast.FLUSH timeout="2000"/>
-    <!-- Enter here NodeName@ClusterName -->
-    <!-- BE AWARE, it's case sensitive. So put *EXACTLY* the name of the node as it's set up on the existing cluster -->
-    <pbcast.GMS name="THIS_IS_YOUR_CALLSIGN_AS_ITS_IN_SETUP_IN_THE_CLUSTER@DAPNET"
-                print_local_addr="false"/>
+    <!-- ATTENTION : NodeName + ChannelName has moved to settings.json !!!!! -->
+    <pbcast.GMS print_local_addr="false"/>
 </config>

--- a/example_config/Settings.json
+++ b/example_config/Settings.json
@@ -25,7 +25,9 @@
   },
   "clusterSettings": {
     "responseTimeout": 10000,
-    "clusterConfigurationFile": "../local/config/ClusterConfig.xml"
+    "clusterConfigurationFile": "../local/config/ClusterConfig.xml",
+    "nodeName": "THIS_IS_YOUR_CALLSIGN_AS_ITS_IN_SETUP_IN_THE_CLUSTER",
+    "channelName": "DAPNET"
   },
   "schedulerSettings": {
     "timeTransmissionCron": "0 0/2 * * * ?",

--- a/src/main/java/org/dapnet/core/cluster/ClusterManager.java
+++ b/src/main/java/org/dapnet/core/cluster/ClusterManager.java
@@ -165,7 +165,7 @@ public class ClusterManager implements TransmitterManagerListener, RestListener 
 	// ### Helper for reading Cluster Config
 	// ############################################################################
 	private String readChannelName() {
-		String channelName = Settings.getClusterSettings().getChannelName();
+		String channelName = Settings.getClusterSettings().getChannelName() + DAPNETCore.getCoreVersion();
 		logger.info("readChannelName from Settings: " + channelName);
 		return channelName;
 	}

--- a/src/main/java/org/dapnet/core/cluster/ClusterManager.java
+++ b/src/main/java/org/dapnet/core/cluster/ClusterManager.java
@@ -165,23 +165,15 @@ public class ClusterManager implements TransmitterManagerListener, RestListener 
 	// ### Helper for reading Cluster Config
 	// ############################################################################
 	private String readChannelName() {
-		// Ugly solution but prevents the use of a second configuration file
-		String properties = channel.getProperties();
-		int gmsPosition = properties.indexOf("pbcast.GMS");
-		int namePosition = properties.indexOf("name=", gmsPosition);
-		int startPosition = properties.indexOf('@', namePosition) + 1;
-		int endPosition = properties.indexOf(';', startPosition);
-		return properties.substring(startPosition, endPosition) + DAPNETCore.getCoreVersion();
+		String channelName = Settings.getClusterSettings().getChannelName();
+		logger.info("readChannelName from Settings: " + channelName);
+		return channelName;
 	}
 
 	private String readNodeName() {
-		// Ugly solution but prevents the use of a second configuration file
-		String properties = channel.getProperties();
-		int gmsPosition = properties.indexOf("pbcast.GMS");
-		int namePosition = properties.indexOf("name=", gmsPosition);
-		int startPosition = namePosition + 5;
-		int endPosition = properties.indexOf('@', startPosition);
-		return properties.substring(startPosition, endPosition);
+		String nodeName = Settings.getClusterSettings().getNodeName();
+		logger.info("readNodeName from Settings: " + nodeName);
+		return nodeName;
 	}
 
 	// ### Quorum

--- a/src/main/java/org/dapnet/core/cluster/ClusterSettings.java
+++ b/src/main/java/org/dapnet/core/cluster/ClusterSettings.java
@@ -21,6 +21,10 @@ public class ClusterSettings implements Serializable {
 	private int responseTimeout = 10000;
 	private String clusterConfigurationFile = "config/ClusterConfig.xml";
 
+	private String nodeName;
+
+	private String channelName;
+
 	public int getResponseTimeout() {
 		return responseTimeout;
 	}
@@ -28,4 +32,8 @@ public class ClusterSettings implements Serializable {
 	public String getClusterConfigurationFile() {
 		return clusterConfigurationFile;
 	}
+
+	public String getNodeName() { return nodeName; }
+
+	public String getChannelName() { return channelName; }
 }


### PR DESCRIPTION
With the new version of JGroups, it is no longer possible to place NodeName@ChannelName as a "name" parameter in ClusterConfig.xml.

So these parameters moved to the Settings.json file.